### PR TITLE
Streamline deployment steps

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -207,7 +207,7 @@ az eventhubs namespace create --name $INGESTION_EH_NS \
 az eventhubs eventhub create --name $INGESTION_EH_NAME \
                              --resource-group $RESOURCE_GROUP \
                              --namespace-name $INGESTION_EH_NS \
-                             --partition-count 8
+                             --partition-count 4
 
 # Create consumer group
 az eventhubs eventhub consumer-group create --eventhub-name $INGESTION_EH_NAME \

--- a/k8s/scheduler.yaml
+++ b/k8s/scheduler.yaml
@@ -16,7 +16,7 @@ metadata:
     co: fabrikam
 spec:
   serviceName: scheduler
-  replicas: 8
+  replicas: 4
   selector:
     matchLabels:
       app: scheduler 

--- a/k8s/scheduler.yaml
+++ b/k8s/scheduler.yaml
@@ -16,7 +16,7 @@ metadata:
     co: fabrikam
 spec:
   serviceName: scheduler
-  replicas: 32
+  replicas: 8
   selector:
     matchLabels:
       app: scheduler 

--- a/k8s/scheduler.yaml
+++ b/k8s/scheduler.yaml
@@ -84,7 +84,7 @@ spec:
                 name: scheduler-secrets
                 key: queueconstring
           - name: IOTHUB_EVENTHUB_PARTITIONS
-            value: "32"
+            value: "4"
           # Integration with l5d Daemon Sets
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
- Use `-o tsv` to avoid needing to strip quotes
- Pipe sed commands to a new file, so the operation is non-destructive of the source files (idempotent)
- Reduce need to go to Portal for some steps
    - Use CLI to create event hub and get access key
    - Use CLI to get Storage Account access key and connection string
- Use 8 partitions and 8 scheduler replicas, to reduce the footprint for F5 experience
- Clarify which steps are optional for a test deployment