### PR TITLE
Use ConfigurationOptions class to build connection string

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -120,7 +120,8 @@ docker push $ACR_SERVER/fabrikam.dronedelivery.deliveryservice:0.1.0
 Create Kubernetes secrets
 
 ```bash
-export REDIS_CONNECTION_STRING=[YOUR_REDIS_CONNECTION_STRING]
+export REDIS_ENDPOINT=$(az redis show --name $REDIS_NAME --resource-group $RESOURCE_GROUP --query hostName -o tsv)
+export REDIS_KEY=$(az redis list-keys --name $REDIS_NAME --resource-group $RESOURCE_GROUP --query primaryKey -o tsv)
 
 export COSMOSDB_KEY=$(az cosmosdb list-keys --name $COSMOSDB_NAME --resource-group $RESOURCE_GROUP --query primaryMasterKey -o tsv)
 export COSMOSDB_ENDPOINT=$(az cosmosdb show --name $COSMOSDB_NAME --resource-group $RESOURCE_GROUP --query documentEndpoint -o tsv)
@@ -128,7 +129,8 @@ export COSMOSDB_ENDPOINT=$(az cosmosdb show --name $COSMOSDB_NAME --resource-gro
 kubectl --namespace shipping create --save-config=true secret generic delivery-storageconf \
     --from-literal=CosmosDB_Key=${COSMOSDB_KEY} \
     --from-literal=CosmosDB_Endpoint=${COSMOSDB_ENDPOINT} \
-    --from-literal=Redis_ConnectionString=${REDIS_CONNECTION_STRING} \
+    --from-literal=Redis_Endpoint=${REDIS_ENDPOINT} \
+    --from-literal=Redis_AccessKey=${REDIS_KEY} \
     --from-literal=EH_ConnectionString=
 ```
 

--- a/deploymentARM.md
+++ b/deploymentARM.md
@@ -119,7 +119,8 @@ docker push $ACR_SERVER/fabrikam.dronedelivery.deliveryservice:0.1.0
 Create Kubernetes secrets
 
 ```bash
-export REDIS_CONNECTION_STRING=[YOUR_REDIS_CONNECTION_STRING]
+export REDIS_ENDPOINT=$(az redis show --name $REDIS_NAME --resource-group $RESOURCE_GROUP --query hostName -o tsv)
+export REDIS_KEY=$(az redis list-keys --name $REDIS_NAME --resource-group $RESOURCE_GROUP --query primaryKey -o tsv)
 
 export COSMOSDB_NAME=$(az group deployment show -g $RESOURCE_GROUP -n azuredeploy --query properties.outputs.deliveryCosmosDbName.value | sed -e 's/^"//' -e 's/"$//') && \
 export COSMOSDB_KEY=$(az cosmosdb list-keys --name $COSMOSDB_NAME --resource-group $RESOURCE_GROUP --query primaryMasterKey) && \
@@ -128,7 +129,8 @@ export COSMOSDB_ENDPOINT=$(az cosmosdb show --name $COSMOSDB_NAME --resource-gro
 kubectl --namespace shipping create --save-config=true secret generic delivery-storageconf \
     --from-literal=CosmosDB_Key=${COSMOSDB_KEY[@]//\"/} \
     --from-literal=CosmosDB_Endpoint=${COSMOSDB_ENDPOINT[@]//\"/} \
-    --from-literal=Redis_ConnectionString=${REDIS_CONNECTION_STRING} \
+    --from-literal=Redis_Endpoint=${REDIS_ENDPOINT} \
+    --from-literal=Redis_AccessKey=${REDIS_KEY} \
     --from-literal=EH_ConnectionString=
 ```
 

--- a/k8s/delivery.yaml
+++ b/k8s/delivery.yaml
@@ -66,11 +66,16 @@ spec:
           value: "CosmosDB_DatabaseId"
         - name: DOCDB_COLLECTIONID
           value: "CosmosDB_CollectionId"
-        - name: REDIS_CONNSTR
+        - name: REDIS_ENDPOINT
           valueFrom:
              secretKeyRef:
               name: delivery-storageconf
-              key: Redis_ConnectionString
+              key: Redis_Endpoint
+        - name: REDIS_KEY
+          valueFrom:
+             secretKeyRef:
+              name: delivery-storageconf
+              key: Redis_AccessKey
         - name: EH_CONNSTR
           valueFrom:
              secretKeyRef:

--- a/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Services/RedisCache.cs
+++ b/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Services/RedisCache.cs
@@ -16,14 +16,14 @@ namespace Fabrikam.DroneDelivery.DeliveryService.Services
 {
     public static class RedisCache<T> where T : BaseCache
     {
-        private static string ConnectionString;
+        private static ConfigurationOptions ConfigOptions;
         private static int DB;
         private static ILogger logger;
 
         private static Lazy<ConnectionMultiplexer> lazyConnection = new Lazy<ConnectionMultiplexer>(() =>
         {
             // automatically disposed when the AppDomain is torn down
-            var connection = ConnectionMultiplexer.Connect(ConnectionString);
+            var connection = ConnectionMultiplexer.Connect(ConfigOptions);
 
             return connection;
         });
@@ -49,10 +49,16 @@ namespace Fabrikam.DroneDelivery.DeliveryService.Services
             }
         }
 
-        public static void Configure(int db, string connectionString, ILoggerFactory loggerFactory)
+        public static void Configure(int db, string endPoint, string key, ILoggerFactory loggerFactory)
         {
             DB = db;
-            ConnectionString = connectionString;
+            ConfigOptions = new ConfigurationOptions
+            {
+                Password = key,
+                EndPoints = { { endPoint } },
+                Ssl = true,
+                AbortOnConnectFail = false
+            };
             logger = loggerFactory.CreateLogger(nameof(RedisCache<T>));
         }
 

--- a/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Startup.cs
+++ b/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Startup.cs
@@ -87,8 +87,8 @@ namespace Fabrikam.DroneDelivery.DeliveryService
 
             //TODO look into creating a factory of DocDBRepos/RedisCache/EventHubMessenger
             DocumentDBRepository<InternalNotifyMeRequest>.Configure(Configuration["DOCDB_ENDPOINT"], Configuration["DOCDB_KEY"], Configuration["DOCDB_DATABASEID"], Configuration["DOCDB_COLLECTIONID"], loggerFactory);
-            RedisCache<InternalDelivery>.Configure(Constants.RedisCacheDBId_Delivery, Configuration["REDIS_CONNSTR"], loggerFactory);
-            RedisCache<DeliveryTrackingEvent>.Configure(Constants.RedisCacheDBId_DeliveryStatus, Configuration["REDIS_CONNSTR"], loggerFactory);
+            RedisCache<InternalDelivery>.Configure(Constants.RedisCacheDBId_Delivery, Configuration["REDIS_ENDPOINT"], Configuration["REDIS_KEY"], loggerFactory);
+            RedisCache<DeliveryTrackingEvent>.Configure(Constants.RedisCacheDBId_DeliveryStatus, Configuration["REDIS_ENDPOINT"], Configuration["REDIS_KEY"], loggerFactory);
             EventHubSender<DeliveryHistory>.Configure(Configuration["EH_CONNSTR"], Configuration["EH_ENTITYPATH"]);
         }
     }


### PR DESCRIPTION
The purpose of this PR is to remove the last deployment step that requires going to the Azure Portal.

There is no CLI command to get the Redis connection string. Instead, you can get the endpoint and key and pass these to the ConfigurationOptions class to create the connection.