### PR TITLE
Drone Delivery update in basic version

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -78,26 +78,6 @@
             },
             "type": "string"
         },
-        "agentCount": {
-            "type": "int",
-            "defaultValue": 1,
-            "metadata": {
-                "description": "The number of agents for the cluster.  This value can be from 1 to 100 (note, for Kubernetes clusters you will also get 1 or 2 public agents in addition to these seleted masters)"
-            },
-            "minValue": 1,
-            "maxValue": 100
-        },
-        "agentVMSize": {
-            "type": "string",
-            "defaultValue": "Standard_D2_v2",
-            "allowedValues": [
-                "Standard_D2_v2",
-                "Standard_F8s_v2"
-            ],
-            "metadata": {
-                "description": "The size of the Virtual Machine."
-            }
-        },
         "osType": {
             "type": "string",
             "defaultValue": "Linux",
@@ -185,7 +165,9 @@
                 "droneSchedulerKeyVaultName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "droneSchedulerCosmosDbName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "workflowKeyVaultName": "[concat(parameters('environmentName'),'-wf-',uniqueString(resourceGroup().id))]",
-                "workflowServiceAccessKey": "WorkflowServiceAccessKey"
+                "workflowServiceAccessKey": "WorkflowServiceAccessKey",
+                "agentCount": 1,
+                "agentVMSize": "Standard_D2_v2"
             },
             "qa": {
                 "aksClusterName": "[uniqueString(variables('clusterNamePrefix'), resourceGroup().id)]",
@@ -206,7 +188,9 @@
                 "droneSchedulerKeyVaultName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "droneSchedulerCosmosDbName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "workflowKeyVaultName": "[concat(parameters('environmentName'),'-wf-',uniqueString(resourceGroup().id))]",
-                "workflowServiceAccessKey": "WorkflowServiceAccessKey"
+                "workflowServiceAccessKey": "WorkflowServiceAccessKey",
+                "agentCount": 3,
+                "agentVMSize": "Standard_D2_v2"
             },
             "staging": {
                 "aksClusterName": "[uniqueString(variables('clusterNamePrefix'), resourceGroup().id)]",
@@ -227,7 +211,9 @@
                 "droneSchedulerKeyVaultName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "droneSchedulerCosmosDbName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "workflowKeyVaultName": "[concat(parameters('environmentName'),'-wf-',uniqueString(resourceGroup().id))]",
-                "workflowServiceAccessKey": "WorkflowServiceAccessKey"
+                "workflowServiceAccessKey": "WorkflowServiceAccessKey",
+                "agentCount": 3,
+                "agentVMSize": "Standard_D2_v2"
             },
             "prod": {
                 "aksClusterName": "[uniqueString(variables('clusterNamePrefix'), resourceGroup().id)]",
@@ -248,7 +234,9 @@
                 "droneSchedulerKeyVaultName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "droneSchedulerCosmosDbName": "[concat(parameters('environmentName'),'-ds-',uniqueString(resourceGroup().id))]",
                 "workflowKeyVaultName": "[concat(parameters('environmentName'),'-wf-',uniqueString(resourceGroup().id))]",
-                "workflowServiceAccessKey": "WorkflowServiceAccessKey"
+                "workflowServiceAccessKey": "WorkflowServiceAccessKey",
+                "agentCount": 3,
+                "agentVMSize": "Standard_D2_v2"
             }
         }
     },
@@ -329,8 +317,8 @@
                     {
                         "name": "agentpool",
                         "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
-                        "count": "[parameters('agentCount')]",
-                        "vmSize": "[parameters('agentVMSize')]",
+                        "count": "[variables('environmentSettings')[parameters('environmentName')].agentCount]",
+                        "vmSize": "[variables('environmentSettings')[parameters('environmentName')].agentVMSize]",
                         "osType": "[parameters('osType')]",
                         "storageProfile": "ManagedDisks"
                     }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -80,7 +80,7 @@
         },
         "agentCount": {
             "type": "int",
-            "defaultValue": 3,
+            "defaultValue": 1,
             "metadata": {
                 "description": "The number of agents for the cluster.  This value can be from 1 to 100 (note, for Kubernetes clusters you will also get 1 or 2 public agents in addition to these seleted masters)"
             },

--- a/charts/delivery/envs/delivery-dev/values.yaml
+++ b/charts/delivery/envs/delivery-dev/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "Information"
     reason: "new dev deploy"
     current: true
+    ingress:
+      class: "nginx-dev"
     resources:
       requests:
         cpu: 91m

--- a/charts/delivery/envs/delivery-dev/values.yaml
+++ b/charts/delivery/envs/delivery-dev/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "Information"
     reason: "new dev deploy"
     current: true
+    resources:
+      requests:
+        cpu: 91m
+        memory: 350Mi
+      limits:
+        cpu: 130m
+        memory: 500Mi

--- a/charts/delivery/envs/delivery-prod/values.yaml
+++ b/charts/delivery/envs/delivery-prod/values.yaml
@@ -2,9 +2,16 @@
 nameOverride: delivery
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 2
     image:
       pullPolicy: IfNotPresent
     telemetry:
       level: "Error"
     reason: "new prod deploy"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 350Mi
+      limits:
+        cpu: 200m
+        memory: 500Mi

--- a/charts/delivery/envs/delivery-prod/values.yaml
+++ b/charts/delivery/envs/delivery-prod/values.yaml
@@ -2,12 +2,14 @@
 nameOverride: delivery
 exports:
   data:
-    replicaCount: 2
+    replicaCount: 1
     image:
       pullPolicy: IfNotPresent
     telemetry:
       level: "Error"
     reason: "new prod deploy"
+    ingress:
+      class: "nginx-prod"
     resources:
       requests:
         cpu: 100m

--- a/charts/delivery/envs/delivery-qa/values.yaml
+++ b/charts/delivery/envs/delivery-qa/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "Information"
     reason: "new qa deploy"
     current: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 350Mi
+      limits:
+        cpu: 150m
+        memory: 500Mi

--- a/charts/delivery/envs/delivery-qa/values.yaml
+++ b/charts/delivery/envs/delivery-qa/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "Information"
     reason: "new qa deploy"
     current: true
+    ingress:
+      class: "nginx-qa"
     resources:
       requests:
         cpu: 100m

--- a/charts/delivery/envs/delivery-staging/values.yaml
+++ b/charts/delivery/envs/delivery-staging/values.yaml
@@ -2,13 +2,15 @@
 nameOverride: delivery
 exports:
   data:
-    replicaCount: 2
+    replicaCount: 1
     image:
       pullPolicy: Always
     telemetry:
       level: "Information"
     reason: "new staging deploy"
     current: true
+    ingress:
+      class: "nginx-staging"
     resources:
       requests:
         cpu: 100m

--- a/charts/delivery/envs/delivery-staging/values.yaml
+++ b/charts/delivery/envs/delivery-staging/values.yaml
@@ -2,10 +2,17 @@
 nameOverride: delivery
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 2
     image:
       pullPolicy: Always
     telemetry:
       level: "Information"
     reason: "new staging deploy"
     current: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 350Mi
+      limits:
+        cpu: 200m
+        memory: 500Mi

--- a/charts/delivery/requirements.lock
+++ b/charts/delivery/requirements.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: delivery-dev
+  repository: file://envs/delivery-dev
+  version: v0.1.0
+- name: delivery-prod
+  repository: file://envs/delivery-prod
+  version: v0.1.0
+- name: delivery-qa
+  repository: file://envs/delivery-qa
+  version: v0.1.0
+- name: delivery-staging
+  repository: file://envs/delivery-staging
+  version: v0.1.0
+digest: sha256:8f25310facbaa5f8791424964158ceddd0f5da6994d316422eab26dd02e1e3ec
+generated: "2019-10-22T07:45:01.368035081-06:00"

--- a/charts/delivery/templates/delivery-deploy.yaml
+++ b/charts/delivery/templates/delivery-deploy.yaml
@@ -46,6 +46,38 @@ spec:
       - name: fabrikam-delivery
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        readinessProbe:
+          httpGet:
+            path: {{ required "readinessProbe.httpGet.path is required" .Values.readinessProbe.httpGet.path }}
+            port: {{ required "readinessProbe.httpGet.port is required" .Values.readinessProbe.httpGet.port }}
+{{- if .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: {{ required "livenessProbe.httpGet.path is required" .Values.livenessProbe.httpGet.path }}
+            port: {{ required "livenessProbe.httpGet.port is required" .Values.livenessProbe.httpGet.port }}
+{{- if .Values.livenessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
         resources:
           requests:
             cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}

--- a/charts/delivery/templates/delivery-deploy.yaml
+++ b/charts/delivery/templates/delivery-deploy.yaml
@@ -46,6 +46,13 @@ spec:
       - name: fabrikam-delivery
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          requests:
+            cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
+            memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
+          limits:
+            cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
+            memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}
         env:
         - name: DOCDB_DATABASEID
           value: {{ .Values.cosmosdb.id }}
@@ -60,10 +67,3 @@ spec:
       ports:
         - name: service
           containerPort: 8080
-      resources:
-        requests:
-          cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
-          memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
-        limits:
-          cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
-          memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}

--- a/charts/delivery/templates/delivery-ingress.yaml
+++ b/charts/delivery/templates/delivery-ingress.yaml
@@ -15,6 +15,7 @@ kind: Ingress
 metadata:
   name: {{ $relname }}-ingress
   annotations:
+    kubernetes.io/ingress.class: {{ required "ingress.class is required" .Values.ingress.class | quote }}
     nginx.ingress.kubernetes.io/rewrite-target: /api/deliveries/public$1
 spec:
   {{- if .Values.ingress.tls }}

--- a/charts/delivery/templates/delivery-internal-ingress.yaml
+++ b/charts/delivery/templates/delivery-internal-ingress.yaml
@@ -15,6 +15,7 @@ kind: Ingress
 metadata:
   name: {{ $relname }}-internal-ingress
   annotations:
+    kubernetes.io/ingress.class: {{ required "ingress.class is required" .Values.ingress.class | quote }}
     nginx.ingress.kubernetes.io/rewrite-target: /api/deliveries$1
     nginx.ingress.kubernetes.io/configuration-snippet: |
       internal;

--- a/charts/delivery/values.yaml
+++ b/charts/delivery/values.yaml
@@ -15,6 +15,20 @@ cosmosdb:
   collectionid:
 keyvault:
   uri:
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 40
+  periodSeconds: 15
+  timeoutSeconds: 2
+  failureThreshold: 5
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 50
+  periodSeconds: 15
 telemetry:
   level: "Error"
 reason: unknown

--- a/charts/delivery/values.yaml
+++ b/charts/delivery/values.yaml
@@ -1,4 +1,4 @@
-# Default values for dronedelivery.
+# Default values for delivery.
 nameOverride: delivery
 replicaCount: 1
 identity:
@@ -18,13 +18,6 @@ keyvault:
 telemetry:
   level: "Error"
 reason: unknown
-resources:
-  requests:
-    cpu: 350m
-    memory: 350Mi
-  limits:
-    cpu: 500m
-    memory: 500Mi
 tags:
   dev: false
   prod: false

--- a/charts/dronescheduler/envs/dronescheduler-dev/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-dev/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "Information"
     reason: "new dev deploy"
     current: true
+    ingress:
+      class: "nginx-dev"
     resources:
       requests:
         cpu: 115m

--- a/charts/dronescheduler/envs/dronescheduler-dev/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-dev/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "Information"
     reason: "new dev deploy"
     current: true
+    resources:
+      requests:
+        cpu: 115m
+        memory: 350Mi
+      limits:
+        cpu: 175m
+        memory: 500Mi

--- a/charts/dronescheduler/envs/dronescheduler-prod/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-prod/values.yaml
@@ -8,3 +8,10 @@ exports:
     telemetry:
       level: "Error"
     reason: "new prod deploy"
+    resources:
+      requests:
+        cpu: 130m
+        memory: 350Mi
+      limits:
+        cpu: 270m
+        memory: 500Mi

--- a/charts/dronescheduler/envs/dronescheduler-prod/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-prod/values.yaml
@@ -2,12 +2,14 @@
 nameOverride: dronescheduler
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 1
     image:
       pullPolicy: IfNotPresent
     telemetry:
       level: "Error"
     reason: "new prod deploy"
+    ingress:
+      class: "nginx-prod"
     resources:
       requests:
         cpu: 130m

--- a/charts/dronescheduler/envs/dronescheduler-qa/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-qa/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "Information"
     reason: "new qa deploy"
     current: true
+    resources:
+      requests:
+        cpu: 130m
+        memory: 350Mi
+      limits:
+        cpu: 200m
+        memory: 500Mi

--- a/charts/dronescheduler/envs/dronescheduler-qa/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-qa/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "Information"
     reason: "new qa deploy"
     current: true
+    ingress:
+      class: "nginx-qa"
     resources:
       requests:
         cpu: 130m

--- a/charts/dronescheduler/envs/dronescheduler-staging/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-staging/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "Information"
     reason: "new staging deploy"
     current: true
+    resources:
+      requests:
+        cpu: 130m
+        memory: 350Mi
+      limits:
+        cpu: 270m
+        memory: 500Mi

--- a/charts/dronescheduler/envs/dronescheduler-staging/values.yaml
+++ b/charts/dronescheduler/envs/dronescheduler-staging/values.yaml
@@ -2,13 +2,15 @@
 nameOverride: dronescheduler
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 1
     image:
       pullPolicy: Always
     telemetry:
       level: "Information"
     reason: "new staging deploy"
     current: true
+    ingress:
+      class: "nginx-staging"
     resources:
       requests:
         cpu: 130m

--- a/charts/dronescheduler/requirements.lock
+++ b/charts/dronescheduler/requirements.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: dronescheduler-dev
+  repository: file://envs/dronescheduler-dev
+  version: v0.1.0
+- name: dronescheduler-prod
+  repository: file://envs/dronescheduler-prod
+  version: v0.1.0
+- name: dronescheduler-qa
+  repository: file://envs/dronescheduler-qa
+  version: v0.1.0
+- name: dronescheduler-staging
+  repository: file://envs/dronescheduler-staging
+  version: v0.1.0
+digest: sha256:37064a63155187c00aa56a0083ee9a241f69d0c0cdbdce487b3bcbb40c81b179
+generated: "2019-10-16T15:49:58.129570048-06:00"

--- a/charts/dronescheduler/templates/dronescheduler-deploy.yaml
+++ b/charts/dronescheduler/templates/dronescheduler-deploy.yaml
@@ -46,6 +46,38 @@ spec:
       - name: fabrikam-dronescheduler
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        readinessProbe:
+          httpGet:
+            path: {{ required "readinessProbe.httpGet.path is required" .Values.readinessProbe.httpGet.path }}
+            port: {{ required "readinessProbe.httpGet.port is required" .Values.readinessProbe.httpGet.port }}
+{{- if .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: {{ required "livenessProbe.httpGet.path is required" .Values.livenessProbe.httpGet.path }}
+            port: {{ required "livenessProbe.httpGet.port is required" .Values.livenessProbe.httpGet.port }}
+{{- if .Values.livenessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
         resources:
           requests:
             cpu: {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}

--- a/charts/dronescheduler/templates/dronescheduler-deploy.yaml
+++ b/charts/dronescheduler/templates/dronescheduler-deploy.yaml
@@ -46,6 +46,13 @@ spec:
       - name: fabrikam-dronescheduler
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          requests:
+            cpu: {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
+            memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
+          limits:
+            cpu: {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
+            memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}
         env:
         - name: KEY_VAULT_URI
           value: {{ .Values.keyvault.uri }}
@@ -60,10 +67,3 @@ spec:
       ports:
         - name: service
           containerPort: 8080
-      resources:
-        requests:
-          cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
-          memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
-        limits:
-          cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
-          memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}

--- a/charts/dronescheduler/templates/dronescheduler-internal-ingress.yaml
+++ b/charts/dronescheduler/templates/dronescheduler-internal-ingress.yaml
@@ -15,6 +15,7 @@ kind: Ingress
 metadata:
   name: {{ $relname }}-internal-ingress
   annotations:
+    kubernetes.io/ingress.class: {{ required "ingress.class is required" .Values.ingress.class | quote }}
     nginx.ingress.kubernetes.io/rewrite-target: /api/dronedeliveries$1
     nginx.ingress.kubernetes.io/configuration-snippet: |
       internal;

--- a/charts/dronescheduler/values.yaml
+++ b/charts/dronescheduler/values.yaml
@@ -1,5 +1,5 @@
 # Default values for dronescheduler.
-replicaCount: 3
+replicaCount: 1
 identity:
   clientid:
   resourceid:
@@ -17,13 +17,6 @@ cosmosdb:
 reason: unknown
 telemetry:
   level: "Error"
-resources:
-  requests:
-    cpu: 450m
-    memory: 350Mi
-  limits:
-    cpu: 600m
-    memory: 500Mi
 tags:
   dev: false
   prod: false

--- a/charts/dronescheduler/values.yaml
+++ b/charts/dronescheduler/values.yaml
@@ -14,6 +14,20 @@ keyvault:
 cosmosdb:
   id:
   collectionid:
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 40
+  periodSeconds: 15
+  timeoutSeconds: 2
+  failureThreshold: 5
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 50
+  periodSeconds: 15
 reason: unknown
 telemetry:
   level: "Error"

--- a/charts/ingestion/envs/ingestion-dev/values.yaml
+++ b/charts/ingestion/envs/ingestion-dev/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "info"
     reason: "new dev deploy"
     current: true
+    ingress:
+      class: "nginx-dev"
     resources:
       requests:
         cpu: 129m

--- a/charts/ingestion/envs/ingestion-dev/values.yaml
+++ b/charts/ingestion/envs/ingestion-dev/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "info"
     reason: "new dev deploy"
     current: true
+    resources:
+      requests:
+        cpu: 129m
+        memory: 600Mi
+      limits:
+        cpu: 194m
+        memory: 800Mi

--- a/charts/ingestion/envs/ingestion-prod/values.yaml
+++ b/charts/ingestion/envs/ingestion-prod/values.yaml
@@ -8,9 +8,8 @@ exports:
     telemetry:
       level: "error"
     reason: "new prod deploy"
-    nginx-ingress:
-      controller:
-        replicaCount: 2
+    ingress:
+      class: "nginx-prod"
     resources:
       requests:
         cpu: 150m

--- a/charts/ingestion/envs/ingestion-prod/values.yaml
+++ b/charts/ingestion/envs/ingestion-prod/values.yaml
@@ -11,3 +11,10 @@ exports:
     nginx-ingress:
       controller:
         replicaCount: 2
+    resources:
+      requests:
+        cpu: 150m
+        memory: 600Mi
+      limits:
+        cpu: 300m
+        memory: 800Mi

--- a/charts/ingestion/envs/ingestion-qa/values.yaml
+++ b/charts/ingestion/envs/ingestion-qa/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "info"
     reason: "new qa deploy"
     current: true
+    resources:
+      requests:
+        cpu: 150m
+        memory: 600Mi
+      limits:
+        cpu: 220m
+        memory: 800Mi

--- a/charts/ingestion/envs/ingestion-qa/values.yaml
+++ b/charts/ingestion/envs/ingestion-qa/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "info"
     reason: "new qa deploy"
     current: true
+    ingress:
+      class: "nginx-qa"
     resources:
       requests:
         cpu: 150m

--- a/charts/ingestion/envs/ingestion-staging/values.yaml
+++ b/charts/ingestion/envs/ingestion-staging/values.yaml
@@ -12,3 +12,10 @@ exports:
       controller:
         replicaCount: 2
     current: true
+    resources:
+      requests:
+        cpu: 150m
+        memory: 600Mi
+      limits:
+        cpu: 300m
+        memory: 800Mi

--- a/charts/ingestion/envs/ingestion-staging/values.yaml
+++ b/charts/ingestion/envs/ingestion-staging/values.yaml
@@ -8,9 +8,8 @@ exports:
     telemetry:
       level: "info"
     reason: "new staging deploy"
-    nginx-ingress:
-      controller:
-        replicaCount: 2
+    ingress:
+      class: "nginx-staging"
     current: true
     resources:
       requests:

--- a/charts/ingestion/requirements.lock
+++ b/charts/ingestion/requirements.lock
@@ -1,7 +1,4 @@
 dependencies:
-- name: nginx-ingress
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.6.15
 - name: ingestion-dev
   repository: file://envs/ingestion-dev
   version: v0.1.0
@@ -14,5 +11,5 @@ dependencies:
 - name: ingestion-staging
   repository: file://envs/ingestion-staging
   version: v0.1.0
-digest: sha256:c2cdc67015f90e1ff33c49603a6ece3f2a99dd8e28e88e8756ef99041820b47a
-generated: 2019-05-29T10:41:19.509573491-03:00
+digest: sha256:feee2c2842b5de8b8e7fda4a388b62ff5e85438633a480b40518c1c3371adcc5
+generated: "2019-10-25T14:37:00.76647856-06:00"

--- a/charts/ingestion/requirements.yaml
+++ b/charts/ingestion/requirements.yaml
@@ -1,9 +1,4 @@
 dependencies:
-- name: nginx-ingress
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: ">=1.6.9"
-  condition: nginx-ingress.enabled
-
 - name: ingestion-dev
   repository: "file://envs/ingestion-dev"
   version: ">= 0.0.1"

--- a/charts/ingestion/templates/ingestion-deploy.yaml
+++ b/charts/ingestion/templates/ingestion-deploy.yaml
@@ -45,14 +45,25 @@ spec:
           httpGet:
             path: /actuator/health
             port: 80
-          initialDelaySeconds: 30
-          periodSeconds: 20
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /api/probe
             port: 80
-          initialDelaySeconds: 30
-          periodSeconds: 20
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+        resources:
+          requests:
+            cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
+            memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
+          limits:
+            cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
+            memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}
         env:
         - name: QUEUE_NAMESPACE
           valueFrom:
@@ -83,10 +94,3 @@ spec:
           value: {{ default "error" .Values.telemetry.level | quote }}
         - name: CONTAINER_NAME
           value: *ingestion-container_name
-      resources:
-        requests:
-          cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
-          memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
-        limits:
-          cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
-          memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}

--- a/charts/ingestion/templates/ingestion-deploy.yaml
+++ b/charts/ingestion/templates/ingestion-deploy.yaml
@@ -41,22 +41,38 @@ spec:
       - name: &ingestion-container_name fabrikam-ingestion
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        livenessProbe:
-          httpGet:
-            path: /actuator/health
-            port: 80
-          initialDelaySeconds: 120
-          periodSeconds: 30
-          successThreshold: 1
-          failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /api/probe
-            port: 80
-          initialDelaySeconds: 120
-          periodSeconds: 30
-          successThreshold: 1
-          failureThreshold: 5
+            path: {{ required "readinessProbe.httpGet.path is required" .Values.readinessProbe.httpGet.path }}
+            port: {{ required "readinessProbe.httpGet.port is required" .Values.readinessProbe.httpGet.port }}
+{{- if .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: {{ required "livenessProbe.httpGet.path is required" .Values.livenessProbe.httpGet.path }}
+            port: {{ required "livenessProbe.httpGet.port is required" .Values.livenessProbe.httpGet.port }}
+{{- if .Values.livenessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
         resources:
           requests:
             cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}

--- a/charts/ingestion/templates/ingestion-ingress.yaml
+++ b/charts/ingestion/templates/ingestion-ingress.yaml
@@ -15,6 +15,7 @@ kind: Ingress
 metadata:
   name: {{ $relname }}-ingress
   annotations:
+    kubernetes.io/ingress.class: {{ required "ingress.class is required" .Values.ingress.class | quote }}
     nginx.ingress.kubernetes.io/rewrite-target: /api/deliveryrequests$1
 spec:
   {{- if .Values.ingress.tls }}

--- a/charts/ingestion/values.yaml
+++ b/charts/ingestion/values.yaml
@@ -9,14 +9,6 @@ image:
 reason: unknown
 telemetry:
   level: "error"
-nginx-ingress:
-  fullnameOverride: nginx-ingress
-  rbac:
-    create: true
-  controller:
-    scope:
-      enabled: true
-  enabled: false
 tags:
   dev: false
   prod: false

--- a/charts/ingestion/values.yaml
+++ b/charts/ingestion/values.yaml
@@ -9,13 +9,6 @@ image:
 reason: unknown
 telemetry:
   level: "error"
-resources:
-  requests:
-    cpu: 500m
-    memory: 600Mi
-  limits:
-    cpu: 650m
-    memory: 800Mi
 nginx-ingress:
   fullnameOverride: nginx-ingress
   rbac:

--- a/charts/ingestion/values.yaml
+++ b/charts/ingestion/values.yaml
@@ -7,6 +7,22 @@ image:
   tag:
   pullPolicy: IfNotPresent
 reason: unknown
+livenessProbe:
+  httpGet:
+    path: /actuator/health
+    port: 80
+  initialDelaySeconds: 120
+  periodSeconds: 30
+  successThreshold: 1
+  failureThreshold: 5
+readinessProbe:
+  httpGet:
+    path: /api/probe
+    port: 80
+  initialDelaySeconds: 120
+  periodSeconds: 30
+  successThreshold: 1
+  failureThreshold: 5
 telemetry:
   level: "error"
 tags:

--- a/charts/package/envs/package-dev/values.yaml
+++ b/charts/package/envs/package-dev/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "info"
     reason: "new dev deploy"
     current: true
+    resources:
+      requests:
+        cpu: 78m
+        memory: 100Mi
+      limits:
+        cpu: 117m
+        memory: 140Mi

--- a/charts/package/envs/package-dev/values.yaml
+++ b/charts/package/envs/package-dev/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "info"
     reason: "new dev deploy"
     current: true
+    ingress:
+      class: "nginx-dev"
     resources:
       requests:
         cpu: 78m

--- a/charts/package/envs/package-prod/values.yaml
+++ b/charts/package/envs/package-prod/values.yaml
@@ -8,3 +8,10 @@ exports:
     log:
       level: "error"
     reason: "new prod deploy"
+    resources:
+      requests:
+        cpu: 90m
+        memory: 100Mi
+      limits:
+        cpu: 180m
+        memory: 140Mi

--- a/charts/package/envs/package-prod/values.yaml
+++ b/charts/package/envs/package-prod/values.yaml
@@ -2,12 +2,14 @@
 nameOverride: package
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 1
     image:
       pullPolicy: IfNotPresent
     log:
       level: "error"
     reason: "new prod deploy"
+    ingress:
+      class: "nginx-prod"
     resources:
       requests:
         cpu: 90m

--- a/charts/package/envs/package-qa/values.yaml
+++ b/charts/package/envs/package-qa/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "info"
     reason: "new qa deploy"
     current: true
+    resources:
+      requests:
+        cpu: 90m
+        memory: 100Mi
+      limits:
+        cpu: 130m
+        memory: 140Mi

--- a/charts/package/envs/package-qa/values.yaml
+++ b/charts/package/envs/package-qa/values.yaml
@@ -9,6 +9,8 @@ exports:
       level: "info"
     reason: "new qa deploy"
     current: true
+    ingress:
+      class: "nginx-qa"
     resources:
       requests:
         cpu: 90m

--- a/charts/package/envs/package-staging/values.yaml
+++ b/charts/package/envs/package-staging/values.yaml
@@ -2,13 +2,15 @@
 nameOverride: package
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 1
     image:
       pullPolicy: Always
     log:
       level: "info"
     reason: "new staging deploy"
     current: true
+    ingress:
+      class: "nginx-staging"
     resources:
       requests:
         cpu: 90m

--- a/charts/package/envs/package-staging/values.yaml
+++ b/charts/package/envs/package-staging/values.yaml
@@ -9,3 +9,10 @@ exports:
       level: "info"
     reason: "new staging deploy"
     current: true
+    resources:
+      requests:
+        cpu: 90m
+        memory: 100Mi
+      limits:
+        cpu: 180m
+        memory: 140Mi

--- a/charts/package/requirements.lock
+++ b/charts/package/requirements.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: package-dev
+  repository: file://envs/package-dev
+  version: v0.1.0
+- name: package-prod
+  repository: file://envs/package-prod
+  version: v0.1.0
+- name: package-qa
+  repository: file://envs/package-qa
+  version: v0.1.0
+- name: package-staging
+  repository: file://envs/package-staging
+  version: v0.1.0
+digest: sha256:058409196b33c962ddb1c1a554013e7840c7ccfc1ddf3a98e12559aeeef05b91
+generated: "2019-10-22T08:05:25.923366271-06:00"

--- a/charts/package/templates/package-deploy.yaml
+++ b/charts/package/templates/package-deploy.yaml
@@ -41,6 +41,38 @@ spec:
       - name: &package-container_name fabrikam-package
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        readinessProbe:
+          httpGet:
+            path: {{ required "readinessProbe.httpGet.path is required" .Values.readinessProbe.httpGet.path }}
+            port: {{ required "readinessProbe.httpGet.port is required" .Values.readinessProbe.httpGet.port }}
+{{- if .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: {{ required "livenessProbe.httpGet.path is required" .Values.livenessProbe.httpGet.path }}
+            port: {{ required "livenessProbe.httpGet.port is required" .Values.livenessProbe.httpGet.port }}
+{{- if .Values.livenessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
         resources:
           requests:
             cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}

--- a/charts/package/templates/package-deploy.yaml
+++ b/charts/package/templates/package-deploy.yaml
@@ -41,6 +41,13 @@ spec:
       - name: &package-container_name fabrikam-package
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          requests:
+            cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
+            memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
+          limits:
+            cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
+            memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}
         env:
         - name: CONNECTION_STRING
           valueFrom:
@@ -61,10 +68,3 @@ spec:
         ports:
         - name: service
           containerPort: 80
-      resources:
-        requests:
-          cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
-          memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
-        limits:
-          cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
-          memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}

--- a/charts/package/templates/package-internal-ingress.yaml
+++ b/charts/package/templates/package-internal-ingress.yaml
@@ -15,6 +15,7 @@ kind: Ingress
 metadata:
   name: {{ $relname }}-internal-ingress
   annotations:
+    kubernetes.io/ingress.class: {{ required "ingress.class is required" .Values.ingress.class | quote }}
     nginx.ingress.kubernetes.io/rewrite-target: /api/package$1
     nginx.ingress.kubernetes.io/configuration-snippet: |
       internal;

--- a/charts/package/values.yaml
+++ b/charts/package/values.yaml
@@ -8,6 +8,20 @@ image:
   tag:
   pullPolicy: IfNotPresent
 reason: unknown
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 80
+  initialDelaySeconds: 40
+  periodSeconds: 15
+  timeoutSeconds: 2
+  failureThreshold: 5
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 80
+  initialDelaySeconds: 50
+  periodSeconds: 15
 log:
   level: error
 cosmosDb:

--- a/charts/package/values.yaml
+++ b/charts/package/values.yaml
@@ -12,13 +12,6 @@ log:
   level: error
 cosmosDb:
   collectionName:
-resources:
-  requests:
-    cpu: 300m
-    memory: 100Mi
-  limits:
-    cpu: 410m
-    memory: 140Mi
 tags:
   dev: false
   prod: false

--- a/charts/workflow/envs/workflow-dev/values.yaml
+++ b/charts/workflow/envs/workflow-dev/values.yaml
@@ -8,3 +8,10 @@ exports:
     telemetry:
       level: "Information"
     reason: "new dev deploy"
+    resources:
+      requests:
+        cpu: 442m
+        memory: 100Mi
+      limits:
+        cpu: 664m
+        memory: 140Mi

--- a/charts/workflow/envs/workflow-prod/values.yaml
+++ b/charts/workflow/envs/workflow-prod/values.yaml
@@ -8,3 +8,10 @@ exports:
     telemetry:
       level: "Error"
     reason: "new prod deploy"
+    resources:
+      requests:
+        cpu: 515m
+        memory: 100Mi
+      limits:
+        cpu: 1000m
+        memory: 140Mi

--- a/charts/workflow/envs/workflow-prod/values.yaml
+++ b/charts/workflow/envs/workflow-prod/values.yaml
@@ -2,7 +2,7 @@
 nameOverride: workflow
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 1
     image:
       pullPolicy: IfNotPresent
     telemetry:

--- a/charts/workflow/envs/workflow-qa/values.yaml
+++ b/charts/workflow/envs/workflow-qa/values.yaml
@@ -8,3 +8,10 @@ exports:
     telemetry:
       level: "Information"
     reason: "new qa deploy"
+    resources:
+      requests:
+        cpu: 515m
+        memory: 100Mi
+      limits:
+        cpu: 770m
+        memory: 140Mi

--- a/charts/workflow/envs/workflow-staging/values.yaml
+++ b/charts/workflow/envs/workflow-staging/values.yaml
@@ -8,3 +8,10 @@ exports:
     telemetry:
       level: "Information"
     reason: "new staging deploy"
+    resources:
+      requests:
+        cpu: 515m
+        memory: 100Mi
+      limits:
+        cpu: 1000m
+        memory: 140Mi

--- a/charts/workflow/envs/workflow-staging/values.yaml
+++ b/charts/workflow/envs/workflow-staging/values.yaml
@@ -2,7 +2,7 @@
 nameOverride: workflow
 exports:
   data:
-    replicaCount: 3
+    replicaCount: 1
     image:
       pullPolicy: Always
     telemetry:

--- a/charts/workflow/requirements.lock
+++ b/charts/workflow/requirements.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: workflow-dev
+  repository: file://envs/workflow-dev
+  version: v0.1.0
+- name: workflow-prod
+  repository: file://envs/workflow-prod
+  version: v0.1.0
+- name: workflow-qa
+  repository: file://envs/workflow-qa
+  version: v0.1.0
+- name: workflow-staging
+  repository: file://envs/workflow-staging
+  version: v0.1.0
+digest: sha256:55b157e79d9bdb5a1a768545096e255d5b3fec4cc5a47a622983ebfa62b04b39
+generated: "2019-10-22T08:12:09.57949386-06:00"

--- a/charts/workflow/templates/workflow-deploy.yaml
+++ b/charts/workflow/templates/workflow-deploy.yaml
@@ -46,6 +46,42 @@ spec:
       - name: fabrikam-workflow
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        readinessProbe:
+          exec:
+            command:
+{{- range .Values.readinessProbe.exec.command }}
+            - {{ . | quote }}
+{{- end }}
+{{- if .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+        livenessProbe:
+          exec:
+            command:
+{{- range .Values.livenessProbe.exec.command }}
+            - {{ . | quote }}
+{{- end }}
+{{- if .Values.livenessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
         resources:
           requests:
             cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
@@ -60,6 +96,8 @@ spec:
         env:
         - name: CONFIGURATION_FOLDER
           value: /kvmnt
+        - name: HEALTHCHECK_INITIAL_DELAY
+          value: {{ default "30000" .Values.healthcheck.delay | quote }}
         - name: SERVICE_URI_DELIVERY
           value: {{ .Values.serviceuri.delivery }}
         - name: SERVICE_URI_DRONE

--- a/charts/workflow/templates/workflow-deploy.yaml
+++ b/charts/workflow/templates/workflow-deploy.yaml
@@ -46,6 +46,13 @@ spec:
       - name: fabrikam-workflow
         image: {{ .Values.dockerregistry }}{{ .Values.dockerregistrynamespace }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          requests:
+            cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
+            memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
+          limits:
+            cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
+            memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}
         volumeMounts:
         - name: workflow
           mountPath: /kvmnt
@@ -90,10 +97,3 @@ spec:
             resourcegroup: {{ .Values.keyvault.resourcegroup }}
             subscriptionid: {{ .Values.keyvault.subscriptionid }}
             tenantid: {{ .Values.keyvault.tenantid }}
-      resources:
-        requests:
-          cpu:   {{ required "A valid .Values.resources.requests.cpu entry required!" .Values.resources.requests.cpu }}
-          memory: {{ required "A valid .Values.resources.requests.memory entry required!" .Values.resources.requests.memory }}
-        limits:
-          cpu:   {{ required "A valid .Values.resources.limits.cpu entry required!" .Values.resources.limits.cpu }}
-          memory: {{ required "A valid .Values.resources.limits.memory entry required!" .Values.resources.limits.memory }}

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -30,13 +30,6 @@ keyvault:
   tenantid:
 telemetry:
   level: "Error"
-resources:
-  requests:
-    cpu: 1700m
-    memory: 100Mi
-  limits:
-    cpu: 2300m
-    memory: 140Mi
 tags:
   dev: false
   prod: false

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -23,6 +23,26 @@ servicerequest:
   circuitbreakerbreakduration: 30
   maxbulkheadsize: 100
   maxbulkheadqueuesize: 25
+healthcheck:
+  delay:
+readinessProbe:
+  exec:
+    command:
+    - cat
+    - /app/healthz
+  initialDelaySeconds: 40
+  periodSeconds: 15
+  timeoutSeconds: 2
+  failureThreshold: 5
+livenessProbe:
+  exec:
+    command:
+    - find
+    - /app/healthz
+    - -mmin
+    - -1
+  initialDelaySeconds: 50
+  periodSeconds: 30
 keyvault:
   name:
   resourcegroup:

--- a/deployment.md
+++ b/deployment.md
@@ -179,12 +179,12 @@ kubectl create -f https://raw.githubusercontent.com/Azure/kubernetes-keyvault-fl
 
 ```bash
 # Deploy the ngnix ingress controller
-helm install stable/nginx-ingress --name nginx-ingress --namespace ingress-controllers --set rbac.create=true
+helm install stable/nginx-ingress --name nginx-ingress-dev --namespace ingress-controllers --set rbac.create=true --set controller.ingressClass=nginx-dev
 
 # Obtain the load balancer ip address and assign a domain name
-until export INGRESS_LOAD_BALANCER_IP=$(kubectl get services/nginx-ingress-controller -n ingress-controllers -o jsonpath="{.status.loadBalancer.ingress[0].ip}" 2> /dev/null) && test -n "$INGRESS_LOAD_BALANCER_IP"; do echo "Waiting for load balancer deployment" && sleep 20; done
+until export INGRESS_LOAD_BALANCER_IP=$(kubectl get services/nginx-ingress-dev-controller -n ingress-controllers -o jsonpath="{.status.loadBalancer.ingress[0].ip}" 2> /dev/null) && test -n "$INGRESS_LOAD_BALANCER_IP"; do echo "Waiting for load balancer deployment" && sleep 20; done
 export INGRESS_LOAD_BALANCER_IP_ID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$INGRESS_LOAD_BALANCER_IP')].[id]" --output tsv)
-export EXTERNAL_INGEST_DNS_NAME="${RESOURCE_GROUP}-ingest"
+export EXTERNAL_INGEST_DNS_NAME="${RESOURCE_GROUP}-ingest-dev"
 export EXTERNAL_INGEST_FQDN=$(az network public-ip update --ids $INGRESS_LOAD_BALANCER_IP_ID --dns-name $EXTERNAL_INGEST_DNS_NAME --query "dnsSettings.fqdn" --output tsv)
 
 # Create a self-signed certificate for TLS

--- a/deployment.md
+++ b/deployment.md
@@ -136,7 +136,7 @@ sudo az aks install-cli
 az aks get-credentials --resource-group=$RESOURCE_GROUP --name=$CLUSTER_NAME
 
 # Create namespaces
-kubectl create namespace backend
+kubectl create namespace backend-dev
 ```
 
 Setup Helm in the container
@@ -192,6 +192,12 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
     -out ingestion-ingress-tls.crt \
     -keyout ingestion-ingress-tls.key \
     -subj "/CN=${EXTERNAL_INGEST_FQDN}/O=fabrikam"
+```
+
+## Setup cluster resource quota
+
+```bash
+kubectl apply -f $K8S/k8s-resource-quotas-dev.yaml
 ```
 
 ## Deploy the Delivery service

--- a/deploymentCICD.md
+++ b/deploymentCICD.md
@@ -51,7 +51,8 @@ az group deployment create -g $RESOURCE_GROUP --name azuredeploy-${env} --templa
                workflowPrincipalId=$WORKFLOW_ID_PRINCIPAL_ID \
                acrResourceGroupName=${RESOURCE_GROUP_ACR} \
                acrResourceGroupLocation=$LOCATION \
-               environmentName=${env}
+               environmentName=${env} \
+               agentCount=3
 
 export {${ENV}_AI_NAME,AI_NAME}=$(az group deployment show -g $RESOURCE_GROUP -n azuredeploy-${env} --query properties.outputs.appInsightsName.value -o tsv)
 export ${ENV}_AI_IKEY=$(az resource show -g $RESOURCE_GROUP -n $AI_NAME --resource-type "Microsoft.Insights/components" --query properties.InstrumentationKey -o tsv)
@@ -109,6 +110,12 @@ Note: the tested nmi version was 1.4. It enables namespaced pod identity.
 kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment-rbac.yaml
 
 kubectl create -f https://raw.githubusercontent.com/Azure/kubernetes-keyvault-flexvol/master/deployment/kv-flexvol-installer.yaml
+```
+
+## Setup cluster resource quota
+
+```bash
+kubectl apply -f $K8S/k8s-resource-quotas-dev.yaml -f $K8S/k8s-resource-quotas-qa-stg-prod.yaml
 ```
 
 ## Setup Azure DevOps

--- a/k8s/k8s-resource-quotas-dev.yaml
+++ b/k8s/k8s-resource-quotas-dev.yaml
@@ -1,0 +1,17 @@
+#  ------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation.  All rights reserved.
+#   Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+#  ------------------------------------------------------------
+
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: dev
+  namespace: backend-dev
+spec:
+  hard:
+    requests.cpu: "1"
+    requests.memory: 2Gi
+    limits.cpu: "2"
+    limits.memory: 5Gi
+    pods: "5"

--- a/k8s/k8s-resource-quotas-qa-stg-prod.yaml
+++ b/k8s/k8s-resource-quotas-qa-stg-prod.yaml
@@ -1,0 +1,39 @@
+#  ------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation.  All rights reserved.
+#   Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+#  ------------------------------------------------------------
+
+ apiVersion: v1
+ kind: ResourceQuota
+ metadata:
+   name: qa
+   namespace: backend-qa
+ spec:
+   hard:
+     requests.cpu: "1"
+     requests.memory: 2Gi
+     limits.cpu: "2"
+     limits.memory: 5Gi
+     pods: "5"
+ ---
+ apiVersion: v1
+ kind: ResourceQuota
+ metadata:
+   name: staging
+   namespace: backend-staging
+ spec:
+   hard:
+     cpu: "2"
+     memory: 8Gi
+     pods: "10"
+ ---
+ apiVersion: v1
+ kind: ResourceQuota
+ metadata:
+   name: prod
+   namespace: backend
+ spec:
+   hard:
+     cpu: "2"
+     memory: 8Gi
+     pods: "10"

--- a/k8s/k8s-resource-quotas-qa-stg-prod.yaml
+++ b/k8s/k8s-resource-quotas-qa-stg-prod.yaml
@@ -3,37 +3,37 @@
 #   Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 #  ------------------------------------------------------------
 
- apiVersion: v1
- kind: ResourceQuota
- metadata:
-   name: qa
-   namespace: backend-qa
- spec:
-   hard:
-     requests.cpu: "1"
-     requests.memory: 2Gi
-     limits.cpu: "2"
-     limits.memory: 5Gi
-     pods: "5"
- ---
- apiVersion: v1
- kind: ResourceQuota
- metadata:
-   name: staging
-   namespace: backend-staging
- spec:
-   hard:
-     cpu: "2"
-     memory: 8Gi
-     pods: "10"
- ---
- apiVersion: v1
- kind: ResourceQuota
- metadata:
-   name: prod
-   namespace: backend
- spec:
-   hard:
-     cpu: "2"
-     memory: 8Gi
-     pods: "10"
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: qa
+  namespace: backend-qa
+spec:
+  hard:
+    requests.cpu: "1"
+    requests.memory: 2Gi
+    limits.cpu: "2"
+    limits.memory: 5Gi
+    pods: "5"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: staging
+  namespace: backend-staging
+spec:
+  hard:
+    cpu: "2"
+    memory: 8Gi
+    pods: "10"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: prod
+  namespace: backend
+spec:
+  hard:
+    cpu: "2"
+    memory: 8Gi
+    pods: "10"

--- a/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Startup.cs
+++ b/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Startup.cs
@@ -4,11 +4,13 @@
 // ------------------------------------------------------------
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Swagger;
 using Fabrikam.DroneDelivery.DeliveryService.Models;
@@ -21,6 +23,8 @@ namespace Fabrikam.DroneDelivery.DeliveryService
 {
     public class Startup
     {
+        private const string HealCheckName = "ReadinessLiveness";
+
         public Startup(IHostingEnvironment env)
         {
             var builder = new ConfigurationBuilder()
@@ -53,6 +57,11 @@ namespace Fabrikam.DroneDelivery.DeliveryService
             // Add framework services.
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
 
+            // Add health check
+            services.AddHealthChecks().AddCheck(
+                    HealCheckName,
+                    () => HealthCheckResult.Healthy("OK"));
+
             // Register the Swagger generator, defining one or more Swagger documents
             services.AddSwaggerGen(c =>
             {
@@ -78,6 +87,9 @@ namespace Fabrikam.DroneDelivery.DeliveryService
 
             // Important: it has to be second: Enable global exception, error handling
             app.UseGlobalExceptionHandler();
+
+            // Map health checks
+            app.UseHealthChecks("/healthz");
 
             // TODO: Add middleware AuthZ here
 

--- a/src/shipping/dronescheduler/Fabrikam.DroneDelivery.DroneSchedulerService/Startup.cs
+++ b/src/shipping/dronescheduler/Fabrikam.DroneDelivery.DroneSchedulerService/Startup.cs
@@ -4,11 +4,13 @@
 // ------------------------------------------------------------
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement;
 using Fabrikam.DroneDelivery.DroneSchedulerService.Models;
@@ -21,6 +23,8 @@ namespace Fabrikam.DroneDelivery.DroneSchedulerService
 {
     public class Startup
     {
+        private const string HealCheckName = "ReadinessLiveness";
+
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -42,6 +46,11 @@ namespace Fabrikam.DroneDelivery.DroneSchedulerService
             // Add framework services.
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
 
+            // Add health check
+            services.AddHealthChecks().AddCheck(
+                    HealCheckName,
+                    () => HealthCheckResult.Healthy("OK"));
+
             // Register the Swagger generator, defining one or more Swagger documents
             services.AddSwaggerGen(c =>
             {
@@ -61,6 +70,9 @@ namespace Fabrikam.DroneDelivery.DroneSchedulerService
               .WriteTo.Console(new CompactJsonFormatter())
               .ReadFrom.Configuration(Configuration)
               .CreateLogger();
+
+            // Map health checks
+            app.UseHealthChecks("/healthz");
 
             app.UseMvc();
 

--- a/src/shipping/ingestion/azure-pipelines-cd.json
+++ b/src/shipping/ingestion/azure-pipelines-cd.json
@@ -29,9 +29,6 @@
                    "value": "DEV_AI_IKEY_VAR_VAL",
                    "isSecret": true
                },
-               "INGRESS_LOAD_BALANCER_IP": {
-                   "value": "DEV_INGRESS_LOAD_BALANCER_IP_VAR_VAL"
-               },
                "EXTERNAL_INGEST_FQDN": {
                    "value": "DEV_EXTERNAL_INGEST_FQDN_VAR_VAL"
                },
@@ -243,7 +240,7 @@
                                 "chartPath": "",
                                 "version": "",
                                 "releaseName": "$(REPO_NAME)-$(Build.SourceBranchName)-dev",
-                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),nginx-ingress.enabled=true,nginx-ingress.controller.service.loadBalancerIP=$(INGRESS_LOAD_BALANCER_IP),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.dev=true",
+                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.dev=true",
                                 "valueFile": "",
                                 "destination": "",
                                 "canaryimage": "false",
@@ -414,9 +411,6 @@
                "AI_IKEY": {
                    "value": "QA_AI_IKEY_VAR_VAL",
                    "isSecret": true
-               },
-               "INGRESS_LOAD_BALANCER_IP": {
-                   "value": "QA_INGRESS_LOAD_BALANCER_IP_VAR_VAL"
                },
                "EXTERNAL_INGEST_FQDN": {
                    "value": "QA_EXTERNAL_INGEST_FQDN_VAR_VAL"
@@ -629,7 +623,7 @@
                                 "chartPath": "",
                                 "version": "",
                                 "releaseName": "$(REPO_NAME)-$(Build.SourceBranchName)-qa",
-                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),nginx-ingress.enabled=true,nginx-ingress.controller.service.loadBalancerIP=$(INGRESS_LOAD_BALANCER_IP),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.qa=true",
+                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.qa=true",
                                 "valueFile": "",
                                 "destination": "",
                                 "canaryimage": "false",
@@ -800,9 +794,6 @@
                "AI_IKEY": {
                    "value": "STAGING_AI_IKEY_VAR_VAL",
                    "isSecret": true
-               },
-               "INGRESS_LOAD_BALANCER_IP": {
-                   "value": "STAGING_INGRESS_LOAD_BALANCER_IP_VAR_VAL"
                },
                "EXTERNAL_INGEST_FQDN": {
                    "value": "STAGING_EXTERNAL_INGEST_FQDN_VAR_VAL"
@@ -1015,7 +1006,7 @@
                                 "chartPath": "",
                                 "version": "",
                                 "releaseName": "$(REPO_NAME)-$(Build.SourceBranchName)-staging",
-                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),nginx-ingress.enabled=true,nginx-ingress.controller.service.loadBalancerIP=$(INGRESS_LOAD_BALANCER_IP),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.staging=true",
+                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.staging=true",
                                 "valueFile": "",
                                 "destination": "",
                                 "canaryimage": "false",
@@ -1186,9 +1177,6 @@
                "AI_IKEY": {
                    "value": "PROD_AI_IKEY_VAR_VAL",
                    "isSecret": true
-               },
-               "INGRESS_LOAD_BALANCER_IP": {
-                   "value": "PROD_INGRESS_LOAD_BALANCER_IP_VAR_VAL"
                },
                "EXTERNAL_INGEST_FQDN": {
                    "value": "PROD_EXTERNAL_INGEST_FQDN_VAR_VAL"
@@ -1435,7 +1423,7 @@
                                 "chartPath": "",
                                 "version": "",
                                 "releaseName": "$(REPO_NAME)-$(Build.SourceBranchName)",
-                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),nginx-ingress.enabled=true,nginx-ingress.controller.service.loadBalancerIP=$(INGRESS_LOAD_BALANCER_IP),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.prod=true,ingestion-prod.experimental=true",
+                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.prod=true,ingestion-prod.experimental=true",
                                 "valueFile": "",
                                 "destination": "",
                                 "canaryimage": "false",
@@ -1729,7 +1717,7 @@
                                 "chartPath": "",
                                 "version": "",
                                 "releaseName": "$(REPO_NAME)-$(Build.SourceBranchName)",
-                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),nginx-ingress.enabled=true,nginx-ingress.controller.service.loadBalancerIP=$(INGRESS_LOAD_BALANCER_IP),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.prod=true,current=true",
+                                "overrideValues": "image.tag=$(Build.SourceBranchName),image.repository=$(REPO_NAME),dockerregistry=$(ACR_SERVER),ingress.hosts[0].name=$(EXTERNAL_INGEST_FQDN),ingress.hosts[0].serviceName=$(SERVICE_NAME),ingress.hosts[0].tls=true,ingress.hosts[0].tlsSecretName=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].name=$(INGRESS_TLS_SECRET_NAME),ingress.tls.secrets[0].key=\"$(INGRESS_TLS_SECRET_KEY)\",ingress.tls.secrets[0].certificate=\"$(INGRESS_TLS_SECRET_CERT)\",secrets.appinsights.ikey=$(AI_IKEY),secrets.queue.keyname=IngestionServiceAccessKey,secrets.queue.keyvalue=$(INGESTION_ACCESS_KEY_VALUE),secrets.queue.name=$(INGESTION_QUEUE_NAME),secrets.queue.namespace=$(INGESTION_QUEUE_NAMESPACE),reason=\"$(REASON)\",tags.prod=true,current=true",
                                 "valueFile": "",
                                 "destination": "",
                                 "canaryimage": "false",

--- a/src/shipping/package/app/server.ts
+++ b/src/shipping/package/app/server.ts
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+const _ = require('koa-route');
 import * as Koa from 'koa';
 import * as bodyParser from "koa-bodyparser";
 
@@ -39,6 +40,15 @@ export class PackageService {
 
     // Configure logging
     app.use(logger(Settings.logLevel()));
+
+    // Add simple health check endpoint
+    app.use(_.get('/healthz', (ctx) => {
+        var logger : ILogger = ctx.state.logger;
+        logger.info('Readiness/Liveness Probe Status: %s', "OK");
+
+        ctx.status = 200;
+        ctx.body = {status: 'OK'};
+    }));
 
     // Configure global exception handling
     // Use: ctx.throw('Error Message', 500);

--- a/src/shipping/workflow/Fabrikam.Workflow.Service.Tests/ReadinessLivenessPublisherTests.cs
+++ b/src/shipping/workflow/Fabrikam.Workflow.Service.Tests/ReadinessLivenessPublisherTests.cs
@@ -1,0 +1,120 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Fabrikam.Workflow.Service.Services;
+using Moq;
+using Xunit;
+
+namespace Fabrikam.Workflow.Service.Tests
+{
+    public class ReadinessLivenessPublisherTests
+    {
+        private const int DelayCompletionMs = 1000;
+
+        private readonly ReadinessLivenessPublisher _publisher;
+
+        public ReadinessLivenessPublisherTests()
+        {
+            var servicesBuilder = new ServiceCollection();
+            servicesBuilder.AddLogging(logging => logging.AddDebug());
+            var services = servicesBuilder.BuildServiceProvider();
+
+            _publisher =
+                new ReadinessLivenessPublisher(
+                    services.GetService<ILogger<ReadinessLivenessPublisher>>());
+        }
+
+        [Fact]
+        public async Task WhenPublishingAndReportIsHealthy_FileExists()
+        {
+            // Arrange
+            var healthReportEntries = new Dictionary<string, HealthReportEntry>()
+            {
+                {"healthy", new HealthReportEntry(HealthStatus.Healthy, null,TimeSpan.MinValue, null, null) }
+            };
+
+            // Act
+            await _publisher.PublishAsync(
+                    new HealthReport(healthReportEntries, TimeSpan.MinValue),
+                    new CancellationTokenSource().Token);
+
+            // Arrange
+            Assert.True(File.Exists(ReadinessLivenessPublisher.FilePath));
+        }
+
+        [Fact]
+        public async Task WhenPublishingAndReportIsUnhealthy_FileDateTimeIsNotModified()
+        {
+            // Arrange
+            var healthReportEntries = new Dictionary<string, HealthReportEntry>()
+            {
+                {"healthy", new HealthReportEntry(HealthStatus.Healthy, null,TimeSpan.MinValue, null, null) }
+            };
+
+            await _publisher.PublishAsync(
+                    new HealthReport(
+                        healthReportEntries,
+                        TimeSpan.MinValue),
+                    new CancellationTokenSource().Token);
+
+            healthReportEntries.Add(
+                    "unhealthy",
+                    new HealthReportEntry(
+                        HealthStatus.Unhealthy,
+                        null,TimeSpan.MinValue, null, null));
+
+            // Act
+            DateTime healthyWriteTime = File.GetLastWriteTime(ReadinessLivenessPublisher.FilePath);
+            await _publisher.PublishAsync(
+                    new HealthReport(healthReportEntries, TimeSpan.MinValue),
+                    new CancellationTokenSource().Token);
+
+            // Arrange
+            Assert.True(File.Exists(ReadinessLivenessPublisher.FilePath));
+            Assert.Equal(healthyWriteTime, File.GetLastWriteTime(ReadinessLivenessPublisher.FilePath));
+        }
+
+        [Fact(Timeout = DelayCompletionMs * 3)]
+        public async Task WhenPublishingAndReportIsHealthyTwice_FileDateTimeIsModified()
+        {
+            // Arrange
+            Func<Task> emulatePeriodicHealthCheckAsync =
+                () => Task.Delay(DelayCompletionMs);
+
+            var healthReportEntries = new Dictionary<string, HealthReportEntry>()
+            {
+                {"healthy", new HealthReportEntry(HealthStatus.Healthy, null,TimeSpan.MinValue, null, null) }
+            };
+
+            // Act
+            await _publisher.PublishAsync(
+                    new HealthReport(
+                        healthReportEntries,
+                        TimeSpan.MinValue),
+                    new CancellationTokenSource().Token);
+
+            DateTime firstTimehealthyWriteTime = File.GetLastWriteTime(ReadinessLivenessPublisher.FilePath);
+
+            await emulatePeriodicHealthCheckAsync();
+
+            await _publisher.PublishAsync(
+                    new HealthReport(healthReportEntries, TimeSpan.MinValue),
+                    new CancellationTokenSource().Token);
+
+            DateTime sencondTimehealthyWriteTime = File.GetLastWriteTime(ReadinessLivenessPublisher.FilePath);
+
+            // Arrange
+            Assert.True(firstTimehealthyWriteTime < sencondTimehealthyWriteTime);
+        }
+    }
+}

--- a/src/shipping/workflow/Fabrikam.Workflow.Service/Fabrikam.Workflow.Service.csproj
+++ b/src/shipping/workflow/Fabrikam.Workflow.Service/Fabrikam.Workflow.Service.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.9.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/src/shipping/workflow/Fabrikam.Workflow.Service/Services/ReadinessLivenessPublisher.cs
+++ b/src/shipping/workflow/Fabrikam.Workflow.Service/Services/ReadinessLivenessPublisher.cs
@@ -1,0 +1,81 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Fabrikam.Workflow.Service.Services
+{
+    public class ReadinessLivenessPublisher : IHealthCheckPublisher
+    {
+        public const string FilePath = "healthz";
+
+        private readonly ILogger _logger;
+
+        public ReadinessLivenessPublisher(ILogger<ReadinessLivenessPublisher> logger)
+        {
+            this._logger = logger;
+        }
+
+        public Task PublishAsync(HealthReport report,
+                CancellationToken cancellationToken)
+        {
+            switch (report.Status)
+            {
+                case HealthStatus.Healthy:
+                {
+                    this._logger.LogInformation(
+                            "{Timestamp} Readiness/Liveness Probe Status: {Result}",
+                            DateTime.UtcNow,
+                            report.Status);
+
+                    CreateOrUpdateHealthz();
+
+                    break;
+                }
+
+                case HealthStatus.Degraded:
+                {
+                    this._logger.LogWarning(
+                            "{Timestamp} Readiness/Liveness Probe Status: {Result}",
+                            DateTime.UtcNow,
+                            report.Status);
+
+                    break;
+                }
+
+                case HealthStatus.Unhealthy:
+                {
+                    this._logger.LogError(
+                            "{Timestamp} Readiness Probe/Liveness Status: {Result}",
+                            DateTime.UtcNow,
+                            report.Status);
+
+                    break;
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.CompletedTask;
+        }
+
+        private static void CreateOrUpdateHealthz()
+        {
+            if (File.Exists(FilePath))
+            {
+                File.SetLastWriteTimeUtc(FilePath, DateTime.UtcNow);
+            }
+            else
+            {
+                File.AppendText(FilePath).Close();
+            }
+        }
+   }
+}


### PR DESCRIPTION
- enforce resource quotas in dev, qa, staging and production namespaces
- new Resource Requests/Limits allow to start with even a smaller AKS cluster (single node) 
- new Readiness/Liveness endpoints and configuration in delivery, ingestion, workflow, ingestion and package apps
- number of nodes are now drive by the environment settings
- Nginx is now using classes annotations instead of scopes
- bug fixes