### PR TITLE
fixing the testing section so that it works

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -544,10 +544,9 @@ You can send delivery requests and check their statuses using curl.
 Since the certificate used for TLS is self-signed, the request disables TLS validation using the '-k' option.
 
 ```bash
-curl -X POST "https://$EXTERNAL_INGEST_FQDN/api/deliveryrequests" --header 'Content-Type: application/json' --header 'Accept: application/json' -k -i -d '{
+curl -X POST "https://$EXTERNAL_INGEST_FQDN/api/deliveryrequests" --header 'Content-Type: application/json' --header 'Accept: application/json' -k -d '{
    "confirmationRequired": "None",
    "deadline": "",
-   "deliveryId": "mydelivery",
    "dropOffLocation": "drop off",
    "expedited": true,
    "ownerId": "myowner",
@@ -559,13 +558,13 @@ curl -X POST "https://$EXTERNAL_INGEST_FQDN/api/deliveryrequests" --header 'Cont
    },
    "pickupLocation": "my pickup",
    "pickupTime": "2019-05-08T20:00:00.000Z"
- }'
+ }' > deliveryresponse.json
 ```
 
 ### Check the request status
-
 ```bash
-curl "https://$EXTERNAL_INGEST_FQDN/api/deliveries/mydelivery" --header 'Accept: application/json' -k -i
+DELIVERY_ID=$(cat deliveryresponse.json | jq -r .deliveryId)
+curl "https://$EXTERNAL_INGEST_FQDN/api/deliveries/$DELIVERY_ID" --header 'Accept: application/json' -k 
 ```
 
 ## Optional steps


### PR DESCRIPTION
the previous approach assumed that you could set the delivery_id, which you can't. As a result, the confirmation listing call fails with a 404. this captures the delivery_id and then uses that value to see the others. Fixes -- or addresses -- #132