### PR TITLE
enforce basic checkout

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -14,7 +14,11 @@
 Clone or download this repo locally.
 
 ```bash
-git clone https://github.com/mspnp/microservices-reference-implementation.git
+git clone https://github.com/mspnp/microservices-reference-implementation.git && \
+pushd ./microservices-reference-implementation && \
+git checkout basic && \
+popd
+
 ```
 
 The deployment steps shown here use Bash shell commands. On Windows, you can use the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about) to run Bash.


### PR DESCRIPTION
enforcing the basic branch local checkout, we ensure the correct installation type, otherwise in might end up with a hybrid installation between advanced~basic.