### PR TITLE
Required firewall rules update

### DIFF
--- a/azuredeploy-firewall.json
+++ b/azuredeploy-firewall.json
@@ -123,6 +123,24 @@
                                         "9000",
                                         "22"
                                     ]
+                                },
+                                {
+                                    "name": "[concat(variables('regionalRulePrefix'),'TunnelFrontCommToK8sApiServerUdp')]",
+                                    "protocols": [
+                                        "UDP"
+                                    ],
+                                    "sourceAddresses": [
+                                        "[parameters('aksClusterSubnetPrefix')]"
+                                    ],
+                                    "destinationAddresses": [
+                                        "[concat('AzureCloud.',parameters('serviceTagsLocation'))]"
+                                    ],
+                                    "sourceIpGroups": [],
+                                    "destinationIpGroups": [],
+                                    "destinationFqdns": [],
+                                    "destinationPorts": [
+                                        "1194"
+                                    ]
                                 }
                             ]
                         }
@@ -343,7 +361,8 @@
                                         "aksrepos.azurecr.io",
                                         "*mcr.microsoft.com",
                                         "*.cdn.mscr.io",
-                                        "*.blob.core.windows.net"
+                                        "*.blob.core.windows.net",
+                                         "*.data.mcr.microsoft.com"
                                     ]
                                 },
                                 {


### PR DESCRIPTION
closes: #163 

update Azure Firewall rules because Azure Kubernetes Service egress lockdown:

add a content delivery network (CDN) endpoint for Microsoft Container Registry and implementing a new AKS egress lockdown port requirement:

- allow communication with the new Microsoft Container Registry CDN endpoint: *.data.mcr.microsoft.com
- allow UDP port 1194 to communicate with the API server endpoint.